### PR TITLE
Quick fix: controlscene not in build settings

### DIFF
--- a/ProjectSettings/EditorBuildSettings.asset
+++ b/ProjectSettings/EditorBuildSettings.asset
@@ -29,4 +29,7 @@ EditorBuildSettings:
   - enabled: 1
     path: Assets/Scenes/Levels/Level4.unity
     guid: 4d8c07612e4619745a2a85e1fb66fb6d
+  - enabled: 1
+    path: Assets/Scenes/MainMenu/ControlScene.unity
+    guid: f905b3c5ada58c1469dc71684902e673
   m_configObjects: {}


### PR DESCRIPTION
Added ControlScene to BuildSettings so we can load it properly.