### PR TITLE
feat: If ghosts die, the level restarts

### DIFF
--- a/Assets/Hurtable.cs
+++ b/Assets/Hurtable.cs
@@ -1,10 +1,11 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.Events;
 
 public class Hurtable : MonoBehaviour
 {
-    
+    public UnityEvent onDeath;
     [SerializeField] public float health = 100;
     public GameObject hurtableObject;
     public SpriteRenderer sprite;
@@ -37,6 +38,7 @@ public class Hurtable : MonoBehaviour
             hurtableObject.tag = "Dead";
             hurtableObject.layer = deadLayer;
             sprite.enabled = false;
+            onDeath.Invoke();
             yield return new WaitForSeconds(6.0f);
             Die();
         }

--- a/Assets/RestartLevel.cs
+++ b/Assets/RestartLevel.cs
@@ -1,0 +1,12 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+public class RestartLevel : MonoBehaviour
+{
+    public void restartLevel()
+    {
+        SceneManager.LoadScene(SceneManager.GetActiveScene().name);
+    }
+}

--- a/Assets/RestartLevel.cs.meta
+++ b/Assets/RestartLevel.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 60aeafbd011073349be1cae6964668eb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/Levels/Level2.unity
+++ b/Assets/Scenes/Levels/Level2.unity
@@ -131111,6 +131111,51 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &875155832
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 875155834}
+  - component: {fileID: 875155833}
+  m_Layer: 0
+  m_Name: GameObject
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &875155833
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 875155832}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c102b284c98efad469d13b2c25e21a75, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  sceneName: Scene2
+--- !u!4 &875155834
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 875155832}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 8.045673, y: -3.1464698, z: 0.2036053}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 6
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &964816957
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Sheep.prefab
+++ b/Assets/Sheep.prefab
@@ -178,6 +178,7 @@ GameObject:
   - component: {fileID: 6171581157628801624}
   - component: {fileID: 1771796070}
   - component: {fileID: 1771796071}
+  - component: {fileID: 1666129550741254933}
   m_Layer: 8
   m_Name: Sheep
   m_TagString: Soul
@@ -368,6 +369,21 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ebd904b4cc833004294c28a6e25efdba, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  onDeath:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1666129550741254933}
+        m_TargetAssemblyTypeName: RestartLevel, Assembly-CSharp
+        m_MethodName: restartLevel
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
   health: 30
   hurtableObject: {fileID: 2712203939195226490}
   sprite: {fileID: 2712203939195226491}
@@ -402,6 +418,18 @@ MonoBehaviour:
   targets: []
   obstacles: []
   currentTarget: {fileID: 0}
+--- !u!114 &1666129550741254933
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2712203939195226490}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 60aeafbd011073349be1cae6964668eb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &3132494130518141663
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/SoulFire.cs
+++ b/Assets/SoulFire.cs
@@ -9,8 +9,10 @@ public class SoulFire : MonoBehaviour
         Debug.Log("Collision!");
         if (collision.gameObject.layer == LayerMask.NameToLayer("Souls"))
         {
+            collision.gameObject.TryGetComponent<Hurtable>(out Hurtable component);
             Debug.Log("Killed soul");
-            Destroy(collision.gameObject); // fry the soul
+            component.TakeDamage(10000);
+            // Destroy(collision.gameObject); // fry the soul
             // TODO: add animation of soul burning? Maybe dramatic explosion
         }
     }


### PR DESCRIPTION
If any ghosts die, the level restarts.

Code changes:
- Hurtable now has an onDeath UnityEvent that it invokes when it dies.
- SoulFire uses Hurtable instead of destroying the soul outright.
